### PR TITLE
handle profile name edit

### DIFF
--- a/villainary-react/app/interfaces/ProfileFormInputs.ts
+++ b/villainary-react/app/interfaces/ProfileFormInputs.ts
@@ -1,0 +1,6 @@
+import { IntakeFormInputs } from "./IntakeFormInputs";
+
+export type ProfileFormInputs = {
+  laughOnAction: boolean,
+  evilLaughUrl: string,
+} & Pick<IntakeFormInputs, 'villainName'>

--- a/villainary-react/app/profile/Profile.tsx
+++ b/villainary-react/app/profile/Profile.tsx
@@ -1,13 +1,14 @@
 'use client';
-import { Edit } from '@mui/icons-material';
+import { Check, Edit } from '@mui/icons-material';
 import { Grid, TextField } from '@mui/material';
 import { useRouter } from 'next/navigation';
+import { SyntheticEvent, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useDispatch, useSelector } from 'react-redux';
 import { theme } from '../Theme';
 import { Routes } from '../enums/routes';
 import { ProfileFormInputs } from '../interfaces/ProfileFormInputs';
-import { selectUserState } from '../state/userState.slice';
+import { selectUserState, setVillainName } from '../state/userState.slice';
 
 export default function Profile() {
   const {
@@ -19,11 +20,30 @@ export default function Profile() {
   const dispatch = useDispatch();
   const router = useRouter();
 
+  const [editModeToggled, setEditModeToggled] = useState(false);
+
   const villainName = useSelector(selectUserState).villainName;
+  const [tempVillainName, setTempVillainName] = useState(villainName);
 
   if (!villainName) {
     router.push(Routes.ROOT);
   }
+
+  const toggleEditModeOn = () => {
+    setEditModeToggled(true);
+  };
+  const toggleEditModeOff = () => {
+    setEditModeToggled(false);
+  };
+
+  const changeName = (syntheticEvent: SyntheticEvent) => {
+    setTempVillainName((syntheticEvent.target as HTMLInputElement).value);
+  };
+
+  const handleVillainNameUpdate = () => {
+    toggleEditModeOff();
+    dispatch(setVillainName(tempVillainName));
+  };
 
   return (
     <form>
@@ -45,19 +65,29 @@ export default function Profile() {
               formState,
             }) => (
               <TextField
-                {...register('villainName', { required: true })}
+                {...register('villainName', {
+                  required: 'This field is required',
+                })}
                 inputRef={ref}
-                onChange={onChange}
+                onChange={(value) => {
+                  onChange(value);
+                  changeName(value);
+                }}
                 defaultValue={villainName}
                 fullWidth
+                disabled={!editModeToggled}
                 sx={{ backgroundColor: theme.palette.primary.main }}
               />
             )}
           />
-          {errors.villainName && <span>This field is required</span>}
+          {<span>{errors.villainName?.message}</span>}
         </Grid>
         <Grid item xs={4}>
-          <Edit />
+          {editModeToggled ? (
+            <Check onClick={handleVillainNameUpdate} />
+          ) : (
+            <Edit onClick={toggleEditModeOn} />
+          )}
         </Grid>
       </Grid>
     </form>

--- a/villainary-react/app/profile/Profile.tsx
+++ b/villainary-react/app/profile/Profile.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Check, Edit } from '@mui/icons-material';
-import { Grid, TextField } from '@mui/material';
+import { Grid, IconButton, TextField } from '@mui/material';
 import { useRouter } from 'next/navigation';
 import { SyntheticEvent, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -84,9 +84,13 @@ export default function Profile() {
         </Grid>
         <Grid item xs={4}>
           {editModeToggled ? (
-            <Check onClick={handleVillainNameUpdate} />
+            <IconButton onClick={handleVillainNameUpdate} aria-label="save">
+              <Check />
+            </IconButton>
           ) : (
-            <Edit onClick={toggleEditModeOn} />
+            <IconButton onClick={toggleEditModeOn} aria-label="edit">
+              <Edit />
+            </IconButton>
           )}
         </Grid>
       </Grid>


### PR DESCRIPTION
this code adds the custom change event logic for editing villain name on the profile page. 

Users will have their villain name default from state. They can click a pencil Icon to toggle edit mode on, which will enable the input, and then click a checkmark to save the change and toggle edit mode off.