### PR TITLE
redirect to intake form if no villain name

### DIFF
--- a/villainary-react/app/dashboard/page.tsx
+++ b/villainary-react/app/dashboard/page.tsx
@@ -1,11 +1,26 @@
-import Container from "@mui/material/Container";
-import dynamic  from "next/dynamic";
+import { selectUserState } from '@/app/state/userState.slice';
+import Container from '@mui/material/Container';
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { Routes } from '../enums/routes';
 
-const DashboardCard = dynamic(() => import('./DashboardCard'), {ssr: false});
+const DashboardCard = dynamic(() => import('./DashboardCard'), { ssr: false });
+
 export default function Page() {
-    return (
-        <Container maxWidth="sm">
-            <DashboardCard></DashboardCard>
-        </Container>
-    )
+  const router = useRouter();
+  const villainName = useSelector(selectUserState).villainName;
+
+  useEffect(() => {
+    if (!villainName) {
+      router.push(Routes.ROOT);
+    }
+  }, [villainName]);
+
+  return (
+    <Container maxWidth="sm">
+      <DashboardCard></DashboardCard>
+    </Container>
+  );
 }


### PR DESCRIPTION
if the user refreshes, state will be wiped and they will no longer have a villain name. if this occurs on dashboard, they should be routed back to the villain intake form.