### PR TITLE
add products route, refactor menus

### DIFF
--- a/villainary-react/.editorconfig
+++ b/villainary-react/.editorconfig
@@ -1,0 +1,35 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,py,ts,tsx}]
+charset = utf-8
+indent_size = 4
+indent_style = space
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+# Indentation override for all JS under lib directory
+[lib/**.js]
+indent_style = space
+indent_size = 2
+
+# Matches the exact files either package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2

--- a/villainary-react/app/.prettierrc
+++ b/villainary-react/app/.prettierrc
@@ -1,0 +1,10 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "semi": true,
+    "singleQuote": true,
+    "quoteProps": "as-needed",
+    "bracketSpacing": true,
+    "bracketSameLine": false,
+    "arrowParens": "always"
+}

--- a/villainary-react/app/Navbar.tsx
+++ b/villainary-react/app/Navbar.tsx
@@ -7,72 +7,106 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { theme } from './Theme';
+import RouteMenu from './components/RouteMenu';
 import SettingsMenu from './components/SettingsMenu';
 import { Routes } from './enums/routes';
+import { BaseMenuItem } from './interfaces/BaseMenuItem';
 import { selectUserState } from './state/userState.slice';
 
 export default function Navbar() {
-  const router = useRouter();
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const router = useRouter();
+    const [anchorElSettings, setAnchorElSettings] =
+        useState<null | HTMLElement>(null);
+    const [anchorElRoute, setAnchorElRoute] = useState<null | HTMLElement>(
+        null
+    );
 
-  const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
+    const handleSettingsMenu = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorElSettings(event.currentTarget);
+    };
+    const handleRouteMenu = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorElRoute(event.currentTarget);
+    };
 
-  const villainName = useSelector(selectUserState).villainName;
+    const villainName = useSelector(selectUserState).villainName;
 
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
+    const handleSettingsClose = () => {
+        setAnchorElSettings(null);
+    };
+    const handleRouteClose = () => {
+        setAnchorElRoute(null);
+    };
 
-  const handleSettingsMenuClick = () => {
-    router.push(`/${Routes.PROFILE}`);
-  };
+    const handleProfileClick = () => {
+        router.push(`/${Routes.PROFILE}`);
+    };
+    const handleProductsClick = () => {
+        router.push(`/${Routes.PRODUCTS}`);
+    };
 
-  const handleTitleClick = () => {
-    router.push(Routes.ROOT);
-  };
+    const routeMenuItems: BaseMenuItem[] = [
+        { title: 'Products', handleClick: handleProductsClick },
+    ];
+    const settingsMenuItems: BaseMenuItem[] = [
+        { title: 'Profile', handleClick: handleProfileClick },
+    ];
 
-  return (
-    <Box sx={{ flexGrow: 1 }}>
-      <AppBar
-        position="static"
-        sx={{ backgroundColor: theme.palette.secondary.main }}
-      >
-        <Toolbar>
-          <IconButton
-            size="large"
-            edge="start"
-            color="inherit"
-            aria-label="menu"
-            sx={{ mr: 2 }}
-          >
-            <MenuIcon></MenuIcon>
-          </IconButton>
-          <Typography variant="h5" component="div" sx={{ flexGrow: 1 }}>
-            <Link href={Routes.ROOT}>Villainary</Link>
-          </Typography>
-          {villainName ? (
-            <>
-              <IconButton
-                size="large"
-                aria-label="account of current user"
-                aria-controls="menu-appbar"
-                aria-haspopup="true"
-                color="inherit"
-                onClick={handleMenu}
-              >
-                <AccountCircle />
-              </IconButton>
-              <SettingsMenu
-                handleClose={handleClose}
-                anchorEl={anchorEl}
-                handleClick={handleSettingsMenuClick}
-              />
-            </>
-          ) : null}
-        </Toolbar>
-      </AppBar>
-    </Box>
-  );
+    return (
+        <Box sx={{ flexGrow: 1 }}>
+            <AppBar
+                position="static"
+                sx={{ backgroundColor: theme.palette.secondary.main }}
+            >
+                <Toolbar>
+                    {villainName ? (
+                        <>
+                            <IconButton
+                                size="large"
+                                edge="start"
+                                color="inherit"
+                                aria-label="Navigation Menu"
+                                aria-controls="menu-appbar"
+                                sx={{ mr: 2 }}
+                                onClick={handleRouteMenu}
+                            >
+                                <MenuIcon />
+                            </IconButton>
+                            <RouteMenu
+                                anchorEl={anchorElRoute}
+                                handleClose={handleRouteClose}
+                                menuItems={routeMenuItems}
+                            />
+                        </>
+                    ) : null}
+
+                    <Typography
+                        variant="h5"
+                        component="div"
+                        sx={{ flexGrow: 1 }}
+                    >
+                        <Link href={Routes.ROOT}>Villainary</Link>
+                    </Typography>
+                    {villainName ? (
+                        <>
+                            <IconButton
+                                size="large"
+                                aria-label="account of current user"
+                                aria-controls="menu-appbar"
+                                aria-haspopup="true"
+                                color="inherit"
+                                onClick={handleSettingsMenu}
+                            >
+                                <AccountCircle />
+                            </IconButton>
+                            <SettingsMenu
+                                handleClose={handleSettingsClose}
+                                anchorEl={anchorElSettings}
+                                menuItems={settingsMenuItems}
+                            />
+                        </>
+                    ) : null}
+                </Toolbar>
+            </AppBar>
+        </Box>
+    );
 }

--- a/villainary-react/app/components/RouteMenu.tsx
+++ b/villainary-react/app/components/RouteMenu.tsx
@@ -1,13 +1,13 @@
 import { Menu, MenuItem } from '@mui/material';
 import { theme } from '../Theme';
 import { BaseMenuItem } from '../interfaces/BaseMenuItem';
-import { SettingsMenuProps } from '../interfaces/SettingsMenuProps';
+import { RouteMenuProps } from '../interfaces/RouteMenuProps';
 
-export default function SettingsMenu(props: SettingsMenuProps) {
+export default function RouteMenu(props: RouteMenuProps) {
     const { anchorEl, handleClose, menuItems } = props;
     return (
         <Menu
-            id="menu-appbar"
+            id="route-menu-appbar"
             anchorEl={anchorEl}
             anchorOrigin={{
                 vertical: 'top',

--- a/villainary-react/app/dashboard/page.tsx
+++ b/villainary-react/app/dashboard/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { selectUserState } from '@/app/state/userState.slice';
 import Container from '@mui/material/Container';
 import dynamic from 'next/dynamic';
@@ -9,18 +11,18 @@ import { Routes } from '../enums/routes';
 const DashboardCard = dynamic(() => import('./DashboardCard'), { ssr: false });
 
 export default function Page() {
-  const router = useRouter();
-  const villainName = useSelector(selectUserState).villainName;
+    const router = useRouter();
+    const villainName = useSelector(selectUserState).villainName;
 
-  useEffect(() => {
-    if (!villainName) {
-      router.push(Routes.ROOT);
-    }
-  }, [villainName]);
+    useEffect(() => {
+        if (!villainName) {
+            router.push(Routes.ROOT);
+        }
+    }, [villainName]);
 
-  return (
-    <Container maxWidth="sm">
-      <DashboardCard></DashboardCard>
-    </Container>
-  );
+    return (
+        <Container maxWidth="sm">
+            <DashboardCard></DashboardCard>
+        </Container>
+    );
 }

--- a/villainary-react/app/enums/routes.ts
+++ b/villainary-react/app/enums/routes.ts
@@ -1,5 +1,6 @@
 export enum Routes {
   DASHBOARD = 'dashboard',
   PROFILE = 'profile',
+  PRODUCTS = 'products',
   ROOT = '/',
 }

--- a/villainary-react/app/interfaces/BaseMenuItem.ts
+++ b/villainary-react/app/interfaces/BaseMenuItem.ts
@@ -1,0 +1,6 @@
+import { MouseEventHandler } from "react";
+
+export type BaseMenuItem<T = unknown> = {
+  title: string;
+  handleClick: MouseEventHandler<T> | undefined;
+}

--- a/villainary-react/app/interfaces/BaseMenuProps.ts
+++ b/villainary-react/app/interfaces/BaseMenuProps.ts
@@ -1,0 +1,9 @@
+import { PopoverProps } from "@mui/material";
+import { MouseEventHandler } from "react";
+import { BaseMenuItem } from "./BaseMenuItem";
+
+export type BaseMenuProps<T extends BaseMenuItem, U = unknown> = {
+  anchorEl: PopoverProps['anchorEl'];
+  handleClose: PopoverProps['onClose'];
+  menuItems: T[]
+}

--- a/villainary-react/app/interfaces/RouteMenuProps.ts
+++ b/villainary-react/app/interfaces/RouteMenuProps.ts
@@ -1,0 +1,4 @@
+import { BaseMenuItem } from "./BaseMenuItem";
+import { BaseMenuProps } from "./BaseMenuProps";
+
+export type RouteMenuProps = BaseMenuProps<BaseMenuItem>;

--- a/villainary-react/app/interfaces/SettingsMenuProps.ts
+++ b/villainary-react/app/interfaces/SettingsMenuProps.ts
@@ -1,0 +1,4 @@
+import { BaseMenuItem } from "./BaseMenuItem";
+import { BaseMenuProps } from "./BaseMenuProps";
+
+export type SettingsMenuProps = BaseMenuProps<BaseMenuItem>;

--- a/villainary-react/app/products/page.tsx
+++ b/villainary-react/app/products/page.tsx
@@ -1,0 +1,3 @@
+export default function page() {
+    return <div>Hello Products</div>;
+}


### PR DESCRIPTION
This code refactors the navbar to conditionalize the appearance of the nav menu until use has entered a villain name.

* It adds a stub route for products.
* it creates some types related to menus and their props.
* adds a basic prettier and editorconfig set up